### PR TITLE
Fix problem with methods using executeRaw() using Redis Cluster

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisClusterConnection.php
@@ -4,5 +4,54 @@ namespace Illuminate\Redis\Connections;
 
 class PhpRedisClusterConnection extends PhpRedisConnection
 {
-    //
+    /**
+     * Add one or more members to a sorted set or update its score if it already exists.
+     *
+     * @param  string  $key
+     * @param  dynamic  $dictionary
+     * @return int
+     */
+    public function zadd($key, ...$dictionary)
+    {
+        if (is_array(end($dictionary))) {
+            foreach (array_pop($dictionary) as $member => $score) {
+                $dictionary[] = $score;
+                $dictionary[] = $member;
+            }
+        }
+
+        $key = $this->applyPrefix($key);
+
+        return $this->client->zAdd($key, ...$dictionary);
+    }
+
+    /**
+     * Determine if the given keys exist.
+     *
+     * @param  dynamic  $keys
+     * @return int
+     */
+    public function exists(...$keys)
+    {
+        $keys = collect($keys)->map(function ($key) {
+            return $this->applyPrefix($key);
+        });
+
+        return $keys->reduce(function ($carry, $key) {
+            return $carry + $this->client->exists($key);
+        });
+    }
+
+    /**
+     * Apply prefix to the given key if necessary.
+     *
+     * @param  string  $key
+     * @return string
+     */
+    private function applyPrefix($key)
+    {
+        $prefix = (string) $this->client->getOption(\RedisCluster::OPT_PREFIX);
+
+        return $prefix.$key;
+    }
 }


### PR DESCRIPTION
Methods Redis::rawCommand() and RedisCluster::rawCommand() has incompatible interface, so methods zadd() and exists() need different realisation for PhpRedisClusterConnection.
More details in the issue: https://github.com/laravel/framework/issues/29637

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
